### PR TITLE
Update LiveAdapter.java fetchUserProfile() method

### DIFF
--- a/spring-social-live/src/main/java/org/springframework/social/live/connect/LiveAdapter.java
+++ b/spring-social-live/src/main/java/org/springframework/social/live/connect/LiveAdapter.java
@@ -30,7 +30,7 @@ public class LiveAdapter implements ApiAdapter<Live> {
 	public UserProfile fetchUserProfile(Live live) {
 		LiveProfile profile = live.userOperations().getUserProfile();
 		return new UserProfileBuilder().setName(profile.getName()).setFirstName(profile.getFirstName())
-				.setLastName(profile.getLastName()).build();
+				.setLastName(profile.getLastName()).setUsername(profile.getId()).build();
 	}
 
 	public void updateStatus(Live live, String message) {


### PR DESCRIPTION
The fetchUserProfile() method should be setting the UserProfile's username variable. Failure to do so is causing the user ID to be unavailable when implementing the "public String execute(Connection<?> connection)" method of the ConnectionSignUp interface . This may only be an issue with Spring Social 1.1.0.RELEASE
